### PR TITLE
Update Pattern11_BatchedCallbacks.md

### DIFF
--- a/book/chapter2_HowToMakeMixins/Pattern11_BatchedCallbacks.md
+++ b/book/chapter2_HowToMakeMixins/Pattern11_BatchedCallbacks.md
@@ -101,7 +101,8 @@ we implement a simple marker to show how the two elements changes color when tri
 <script type="module">
 import {BatchMixin, runBatchProcess} from "BatchMixin.js";
 
-class One extends HTMLElement;
+class One extends HTMLElement{}
+ 
 class Two extends BatchMixin(HTMLElement){
   batchCallback(){
     this.innerText = "batched";


### PR DESCRIPTION
Class can not be declared as a `class One extends HTMLElement;`